### PR TITLE
プログラミング言語検出ロジックの修正

### DIFF
--- a/lib/supabase/books.ts
+++ b/lib/supabase/books.ts
@@ -350,7 +350,7 @@ async function detectProgrammingLanguagesFromBook(book: Book): Promise<string[]>
     'Scala',
     'Haskell',
     'Perl',
-    'R',
+    // RとCは特別扱いするため、ここでは削除
     'COBOL',
     'Fortran',
     'Assembly',
@@ -365,6 +365,26 @@ async function detectProgrammingLanguagesFromBook(book: Book): Promise<string[]>
   ];
 
   const detectedLanguages = new Set<string>();
+
+  // R言語とC言語の特別処理
+  const lowerTitle = book.title.toLowerCase();
+  // C言語の条件
+  if (
+    lowerTitle.includes('c言語') ||
+    lowerTitle.includes('cプログラミング') ||
+    lowerTitle.includes('c プログラミング')
+  ) {
+    detectedLanguages.add('C');
+  }
+
+  // R言語の条件
+  if (
+    lowerTitle.includes('r言語') ||
+    lowerTitle.includes('rプログラミング') ||
+    lowerTitle.includes('r プログラミング')
+  ) {
+    detectedLanguages.add('R');
+  }
 
   // タイトルから検出
   for (const lang of languages) {

--- a/migrations/003_add_programming_languages.sql
+++ b/migrations/003_add_programming_languages.sql
@@ -20,11 +20,11 @@ DECLARE
     framework TEXT;
 BEGIN
     -- 言語とフレームワークのマスターリスト
-    -- 言語リスト
+    -- 言語リスト（RとCを除外）
     DECLARE languages TEXT[] := ARRAY[
         'JavaScript', 'TypeScript', 'Python', 'Java', 'C++', 'C#', 'Go',
         'Rust', 'Ruby', 'PHP', 'Swift', 'Kotlin', 'Dart', 'Scala', 'Haskell',
-        'Perl', 'R', 'COBOL', 'Fortran', 'Assembly', 'Lua', 'Groovy', 'Clojure',
+        'Perl', 'COBOL', 'Fortran', 'Assembly', 'Lua', 'Groovy', 'Clojure',
         'F#', 'Julia', 'Shell', 'PowerShell', 'SQL'
     ];
 
@@ -50,6 +50,25 @@ BEGIN
     LOOP
         detected_languages := '{}';
         detected_frameworks := '{}';
+
+        -- R言語とC言語の特別処理
+        -- C言語の検出（タイトルに明示的に含まれる場合のみ）
+        IF
+            book_record.title ILIKE '%c言語%' OR
+            book_record.title ILIKE '%cプログラミング%' OR
+            book_record.title ILIKE '%c プログラミング%'
+        THEN
+            detected_languages := array_append(detected_languages, 'C');
+        END IF;
+
+        -- R言語の検出（タイトルに明示的に含まれる場合のみ）
+        IF
+            book_record.title ILIKE '%r言語%' OR
+            book_record.title ILIKE '%rプログラミング%' OR
+            book_record.title ILIKE '%r プログラミング%'
+        THEN
+            detected_languages := array_append(detected_languages, 'R');
+        END IF;
 
         -- タイトルから言語を検出
         FOREACH lang IN ARRAY languages

--- a/scripts/apply-migrations.mjs
+++ b/scripts/apply-migrations.mjs
@@ -86,7 +86,7 @@ async function updateExistingBooks() {
 
     console.log(`${books.length}冊の書籍を処理します`);
 
-    // 言語リスト
+    // 言語リスト（RとCを除外）
     const languages = [
       'JavaScript',
       'TypeScript',
@@ -104,7 +104,6 @@ async function updateExistingBooks() {
       'Scala',
       'Haskell',
       'Perl',
-      'R',
       'COBOL',
       'Fortran',
       'Assembly',
@@ -164,6 +163,27 @@ async function updateExistingBooks() {
     for (const book of books) {
       const detectedLanguages = [];
       const detectedFrameworks = [];
+
+      // R言語とC言語の特別処理
+      const title = book.title?.toLowerCase() || '';
+
+      // C言語の検出（タイトルに明示的に含まれる場合のみ）
+      if (
+        title.includes('c言語') ||
+        title.includes('cプログラミング') ||
+        title.includes('c プログラミング')
+      ) {
+        detectedLanguages.push('C');
+      }
+
+      // R言語の検出（タイトルに明示的に含まれる場合のみ）
+      if (
+        title.includes('r言語') ||
+        title.includes('rプログラミング') ||
+        title.includes('r プログラミング')
+      ) {
+        detectedLanguages.push('R');
+      }
 
       // タイトルから言語を検出
       for (const lang of languages) {


### PR DESCRIPTION
## 修正内容
書籍のプログラミング言語を自動検出するロジックを修正しました。

### 問題点
これまで、多くの書籍に"R"と"C"が含まれていましたが、これらは特定のプログラミング言語を指すケースと単なる文字を指すケースがありました。

### 修正点
以下の3つのファイルを修正し、タイトルに「R言語」や「C言語」などの明示的な記載がある場合のみ、"R"や"C"をプログラミング言語として検出するようにしました：

1. `lib/supabase/books.ts`
2. `migrations/003_add_programming_languages.sql`
3. `scripts/apply-migrations.mjs`

さらに、データベースのトリガーも同様に修正しました。

### テスト結果
- テスト済み環境: ローカル環境およびSupabase上
- 正しく"R"と"C"が適切なタイトル（R言語やC言語を含むもの）のみに追加されることを確認済み