### PR TITLE
書影の上部が切れないように表示方法を修正

### DIFF
--- a/components/home/BookCard.tsx
+++ b/components/home/BookCard.tsx
@@ -40,7 +40,7 @@ export default function BookCard({ book }: BookCardProps) {
               src={book.img_url}
               alt={book.title}
               fill
-              className="object-cover"
+              className="object-contain object-top"
               sizes="(max-width: 640px) 40vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 20vw"
               priority={false}
               quality={85}


### PR DESCRIPTION
## 概要
ホーム画面の各書籍カードで、書影の上部が切れて表示される問題を修正しました。

## 変更内容
- `BookCard.tsx`のImageコンポーネントのclassNameを`object-cover`から`object-contain object-top`に変更
- これにより書影の上部が切れることなく表示されるようになりました
- 下部はグラデーションで徐々に透けているので問題ありません

## スクリーンショット
なし

## 関連Issue
なし