### PR TITLE
fix: ヘッダーのモバイルホバーUI問題を修正

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -52,7 +52,9 @@ export default function Header() {
                 key={tab.name}
                 href={tab.href}
                 className={`px-4 py-2 rounded-lg transition-colors ${
-                  tab.active ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted'
+                  tab.active
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground md:hover:bg-muted'
                 }`}
               >
                 <span>{tab.name}</span>
@@ -66,7 +68,7 @@ export default function Header() {
             variant="ghost"
             size="icon"
             onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            className="rounded-lg"
+            className="rounded-lg md:hover:bg-muted"
           >
             <Sun className="h-5 w-5 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
             <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />


### PR DESCRIPTION
## 修正内容

### 問題
スマートフォンでヘッダーの明暗切り替えボタンやナビゲーションリンクをタッチした際に、ホバー状態が適用されてUIが微妙に見える問題

### 原因
- モバイルデバイスではホバー状態が適切に機能しない
- タッチ後にホバー状態が残ってしまい、デザインが崩れる

### 解決方法
Tailwind CSSのレスポンシブプレフィックス `md:` を使用して、デスクトップ（中サイズ以上の画面）でのみホバー効果を適用

## 変更ファイル
- `components/layout/Header.tsx`

## 技術的な変更

### 1. 明暗切り替えボタン
```tsx
// 変更前
className="rounded-lg"

// 変更後  
className="rounded-lg md:hover:bg-muted"
```

### 2. ナビゲーションリンク
```tsx
// 変更前
'text-muted-foreground hover:bg-muted'

// 変更後
'text-muted-foreground md:hover:bg-muted'
```

## 効果
- ✅ スマートフォンでタッチしてもホバー効果が適用されない
- ✅ デスクトップでは従来通りホバー効果が機能
- ✅ より一貫性のあるモバイルUX

## テスト結果
- ✅ 全テスト通過（112 passed）
- ✅ ESLint/Prettier適用済み

## 関連する修正
この修正は先ほどのフィルターボタンのホバー問題修正（PR #[previous]）と同様のアプローチで、モバイルデバイスでの不要なホバー効果を統一的に除去しています。