### PR TITLE
feat: 経験年数に基づく書籍レコメンド機能の実装

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,6 +63,9 @@ jobs:
     needs: lint-test-build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
 
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +74,6 @@ jobs:
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
@@ -81,6 +83,9 @@ jobs:
     needs: lint-test-build
     if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event.inputs.deploy == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
 
     steps:
       - uses: actions/checkout@v3
@@ -89,7 +94,6 @@ jobs:
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,15 +59,15 @@ jobs:
       - name: ビルドの確認
         run: npm run build
 
-  deploy-dev:
+  deploy-production:
     needs: lint-test-build
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event.inputs.deploy == 'true'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Vercelへのデプロイ
+      - name: 本番環境へのデプロイ
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -76,3 +76,20 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
           vercel-args: '--prod'
+
+  deploy-preview:
+    needs: lint-test-build
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event.inputs.deploy == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: プレビュー環境へのデプロイ
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { calculateRecommendationScore, getExperienceLevel } from '@/lib/utils/recommendations';
+import { Book, RecommendationWithBook, Review } from '@/types';
+
+// 動的ルートとしてマーク
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get('userId');
+    const limit = parseInt(searchParams.get('limit') || '6');
+    const offset = parseInt(searchParams.get('offset') || '0');
+
+    if (!userId) {
+      return NextResponse.json({ error: 'ユーザーIDが必要です' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseServerClient();
+
+    // ユーザーの経験年数を取得
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .select('experience_years')
+      .eq('id', userId)
+      .single();
+
+    if (userError || !userData) {
+      return NextResponse.json({ error: 'ユーザー情報が見つかりません' }, { status: 404 });
+    }
+
+    const userExperienceLevel = getExperienceLevel(userData.experience_years || 0);
+
+    // レビューがある書籍を取得（書籍情報も含む）
+    const { data: reviewsData, error: reviewsError } = await supabase
+      .from('reviews')
+      .select(
+        `
+        *,
+        books (*)
+      `
+      )
+      .not('books', 'is', null);
+
+    if (reviewsError) {
+      return NextResponse.json({ error: 'レビューデータの取得に失敗しました' }, { status: 500 });
+    }
+
+    // 書籍ごとにレビューをグループ化
+    const bookReviewsMap = new Map<string, { book: Book; reviews: Review[] }>();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    reviewsData?.forEach((item: any) => {
+      if (!item.books) return;
+
+      const book: Book = {
+        id: item.books.id,
+        isbn: item.books.isbn || '',
+        title: item.books.title || '',
+        author: item.books.author || '',
+        language: item.books.language || '',
+        categories: item.books.categories || [],
+        img_url: item.books.img_url || '',
+        avg_difficulty: item.books.avg_difficulty || 0,
+        description: item.books.description,
+        programmingLanguages: item.books.programming_languages,
+        frameworks: item.books.frameworks,
+        publisherName: item.books.publisher_name,
+        itemUrl: item.books.item_url,
+      };
+
+      const review: Review = {
+        id: item.id,
+        user_id: item.user_id,
+        user_name: item.user_name || '匿名',
+        book_id: item.book_id,
+        difficulty: item.difficulty,
+        experience_years: item.experience_years,
+        comment: item.comment,
+        created_at: item.created_at,
+        anonymous: item.display_type === 'anon',
+      };
+
+      if (!bookReviewsMap.has(book.id)) {
+        bookReviewsMap.set(book.id, { book, reviews: [] });
+      }
+      bookReviewsMap.get(book.id)!.reviews.push(review);
+    });
+
+    // 各書籍のレコメンドスコアを計算
+    const recommendations: RecommendationWithBook[] = [];
+
+    Array.from(bookReviewsMap.entries()).forEach(([bookId, { book, reviews }]) => {
+      const score = calculateRecommendationScore(bookId, reviews, userExperienceLevel);
+
+      if (score && score.score > 0) {
+        recommendations.push({
+          book,
+          score: score.score,
+          reasons: score.reasons,
+          avgDifficulty: score.avgDifficulty,
+          reviewCount: score.reviewCount,
+          experienceLevelMatch: score.experienceLevelMatch,
+        });
+      }
+    });
+
+    // スコア順にソートしてページネーション適用
+    const sortedRecommendations = recommendations
+      .sort((a, b) => b.score - a.score)
+      .slice(offset, offset + limit);
+
+    return NextResponse.json({
+      recommendations: sortedRecommendations,
+      userExperienceLevel,
+      totalBooks: bookReviewsMap.size,
+    });
+  } catch (error) {
+    return NextResponse.json({ error: 'レコメンドの取得に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/books/layout.tsx
+++ b/app/books/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from 'next';
+
+import { generatePageMetadata } from '@/lib/seo/metadata';
+
+export const metadata: Metadata = generatePageMetadata({
+  title: 'DevLibro - 書籍検索',
+  description: '技術書の検索と閲覧。高解像度の書籍画像でより詳細に確認できます。',
+  path: '/books',
+});
+
+export default function BooksLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -1,22 +1,21 @@
-import { Metadata } from 'next';
+'use client';
+
+import { useState } from 'react';
 
 import FilterButtons from '@/components/home/FilterButtons';
 import RakutenBookGrid from '@/components/rakuten/BookGrid';
 import RakutenSearchBar from '@/components/rakuten/SearchBar';
-import { generatePageMetadata } from '@/lib/seo/metadata';
-
-export const metadata: Metadata = generatePageMetadata({
-  title: 'DevLibro - 書籍検索',
-  description: '技術書の検索と閲覧。高解像度の書籍画像でより詳細に確認できます。',
-  path: '/books',
-});
+import RecommendationSection from '@/components/recommendations/RecommendationSection';
 
 export default function BooksSearchPage() {
+  const [isSearching, setIsSearching] = useState(false);
+
   return (
     <div className="space-y-6 pb-8 pt-8">
       <div className="max-w-2xl mx-auto relative">
-        <RakutenSearchBar />
+        <RakutenSearchBar onSearchStateChange={setIsSearching} />
       </div>
+      {!isSearching && <RecommendationSection />}
       <FilterButtons />
       <RakutenBookGrid />
     </div>

--- a/app/recommendations/page.tsx
+++ b/app/recommendations/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuth } from '@/components/auth/AuthProvider';
+import RecommendationCard from '@/components/recommendations/RecommendationCard';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RecommendationWithBook } from '@/types';
+
+export default function RecommendationsPage() {
+  const { user } = useAuth();
+  const [recommendations, setRecommendations] = useState<RecommendationWithBook[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const fetchRecommendations = useCallback(
+    async (pageNum: number = 1, append: boolean = false) => {
+      if (!user?.id) return;
+
+      try {
+        if (pageNum === 1) {
+          setLoading(true);
+          setError(null);
+        } else {
+          setLoadingMore(true);
+        }
+
+        const limit = 12; // ページあたりの表示数
+        const response = await fetch(
+          `/api/recommendations?userId=${user.id}&limit=${limit}&offset=${(pageNum - 1) * limit}`
+        );
+
+        if (!response.ok) {
+          throw new Error('レコメンドの取得に失敗しました');
+        }
+
+        const data = await response.json();
+
+        if (append) {
+          setRecommendations(prev => [...prev, ...data.recommendations]);
+        } else {
+          setRecommendations(data.recommendations);
+        }
+
+        setHasMore(data.recommendations.length === limit);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'エラーが発生しました');
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [user?.id]
+  );
+
+  useEffect(() => {
+    fetchRecommendations(1, false);
+  }, [fetchRecommendations]);
+
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchRecommendations(nextPage, true);
+  };
+
+  if (!user) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center">
+          <p className="text-muted-foreground">ログインしてレコメンドを表示してください</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">📚 あなたへのおすすめ</h1>
+        <p className="text-muted-foreground">
+          あなたの経験年数とレビューデータに基づいて、最適な書籍をおすすめします
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="space-y-3">
+              <Skeleton className="h-48 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <div className="text-center py-12">
+          <p className="text-red-500 mb-4">{error}</p>
+          <Button onClick={() => fetchRecommendations(1, false)} variant="outline">
+            再試行
+          </Button>
+        </div>
+      ) : recommendations.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground mb-4">現在おすすめできる書籍がありません</p>
+          <p className="text-sm text-muted-foreground">
+            書籍にレビューを投稿すると、より良いレコメンドを提供できます
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {recommendations.map((recommendation, index) => (
+              <div key={recommendation.book.id} className="w-full">
+                <RecommendationCard recommendation={recommendation} index={index} />
+              </div>
+            ))}
+          </div>
+
+          {hasMore && (
+            <div className="text-center mt-8">
+              <Button onClick={handleLoadMore} disabled={loadingMore} variant="outline" size="lg">
+                {loadingMore ? 'ロード中...' : 'さらに読み込む'}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/rakuten/SearchBar.tsx
+++ b/components/rakuten/SearchBar.tsx
@@ -10,7 +10,11 @@ import { Input } from '@/components/ui/input';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useSearchStore } from '@/store/searchStore';
 
-export default function RakutenSearchBar() {
+interface RakutenSearchBarProps {
+  onSearchStateChange?: (isSearching: boolean) => void;
+}
+
+export default function RakutenSearchBar({ onSearchStateChange }: RakutenSearchBarProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [isLocalLoading, setIsLocalLoading] = useState(false);
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
@@ -21,12 +25,7 @@ export default function RakutenSearchBar() {
   const { user } = useAuth();
 
   // 検索ストアから状態と更新関数を取得
-  const {
-    setSearchTerm: setGlobalSearchTerm,
-    resetPagination,
-    clearSearch,
-    setUseRakuten,
-  } = useSearchStore();
+  const { setSearchTerm: setGlobalSearchTerm, clearSearch, setUseRakuten } = useSearchStore();
 
   // 楽天APIを使用することを設定
   useEffect(() => {
@@ -40,13 +39,15 @@ export default function RakutenSearchBar() {
   useEffect(() => {
     if (!debouncedSearchTerm || debouncedSearchTerm.length < 2) {
       setGlobalSearchTerm('');
+      onSearchStateChange?.(false);
       return;
     }
 
     setIsLocalLoading(true);
     setGlobalSearchTerm(debouncedSearchTerm);
+    onSearchStateChange?.(true);
     setIsLocalLoading(false);
-  }, [debouncedSearchTerm, setGlobalSearchTerm]);
+  }, [debouncedSearchTerm, setGlobalSearchTerm, onSearchStateChange]);
 
   const handleSearch = () => {
     if (!searchTerm.trim()) {
@@ -67,6 +68,7 @@ export default function RakutenSearchBar() {
   const handleClear = () => {
     setSearchTerm('');
     clearSearch();
+    onSearchStateChange?.(false);
   };
 
   return (

--- a/components/recommendations/RecommendationCard.tsx
+++ b/components/recommendations/RecommendationCard.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Star } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { getDifficultyInfo } from '@/lib/utils';
+import { RecommendationWithBook } from '@/types';
+
+interface RecommendationCardProps {
+  recommendation: RecommendationWithBook;
+  index: number;
+}
+
+export default function RecommendationCard({ recommendation, index }: RecommendationCardProps) {
+  const { book, score, reasons, avgDifficulty, reviewCount, experienceLevelMatch } = recommendation;
+  const difficultyInfo = getDifficultyInfo(avgDifficulty);
+  const DifficultyIcon = difficultyInfo.icon;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, delay: index * 0.1 }}
+      className="flex-shrink-0 w-80 max-w-full"
+    >
+      <Link href={`/book/${book.id}`} className="block h-full">
+        <Card className="h-full hover:shadow-lg transition-shadow duration-200 cursor-pointer">
+          <CardContent className="p-4 h-full flex flex-col">
+            <div className="flex gap-4 mb-3">
+              {/* 書籍画像 */}
+              <div className="relative h-24 w-16 flex-shrink-0">
+                <Image
+                  src={book.img_url || '/images/book-placeholder.png'}
+                  alt={book.title}
+                  fill
+                  className="object-cover rounded-md"
+                  sizes="64px"
+                />
+              </div>
+
+              {/* 書籍情報 */}
+              <div className="flex-1 min-w-0">
+                <h3
+                  className="font-semibold text-sm line-clamp-2 mb-1 h-10 leading-tight"
+                  title={book.title}
+                >
+                  {book.title}
+                </h3>
+                <p className="text-xs text-muted-foreground line-clamp-1 mb-2" title={book.author}>
+                  {book.author}
+                </p>
+
+                {/* おすすめ度と難易度 */}
+                <div className="flex items-center gap-2 mb-2">
+                  <div className="flex items-center gap-1">
+                    <span className="text-xs text-muted-foreground">おすすめ度</span>
+                    <div className="flex">
+                      {Array.from({ length: 5 }, (_, i) => (
+                        <Star
+                          key={i}
+                          className={`h-3 w-3 ${
+                            i < Math.round(score / 20)
+                              ? 'text-yellow-500 fill-current'
+                              : 'text-gray-300'
+                          }`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  <div
+                    className={`text-xs py-0.5 px-2 rounded-full whitespace-nowrap w-fit min-w-[4rem] flex-shrink-0 font-medium flex items-center justify-center border ${
+                      difficultyInfo.color === 'difficulty-easy'
+                        ? 'bg-red-50 text-red-600 border-red-200'
+                        : difficultyInfo.color === 'difficulty-somewhat-easy'
+                          ? 'bg-yellow-50 text-yellow-600 border-yellow-200'
+                          : difficultyInfo.color === 'difficulty-normal'
+                            ? 'bg-green-50 text-green-600 border-green-200'
+                            : difficultyInfo.color === 'difficulty-somewhat-hard'
+                              ? 'bg-blue-50 text-blue-600 border-blue-200'
+                              : difficultyInfo.color === 'difficulty-hard'
+                                ? 'bg-purple-50 text-purple-600 border-purple-200'
+                                : 'bg-gray-50 text-gray-600 border-gray-200'
+                    }`}
+                  >
+                    <DifficultyIcon className="h-3 w-3 flex-shrink-0 mr-0.5" />
+                    <span>{difficultyInfo.label}</span>
+                  </div>
+                </div>
+
+                {/* レビュー情報 */}
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span>{reviewCount}件のレビュー</span>
+                  {experienceLevelMatch > 0 && <span>• 同レベル{experienceLevelMatch}件</span>}
+                </div>
+              </div>
+            </div>
+
+            {/* レコメンド理由 */}
+            <div className="space-y-1 flex-1">
+              {reasons.slice(0, 2).map((reason, idx) => (
+                <div key={idx} className="text-xs text-muted-foreground">
+                  {reason}
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </Link>
+    </motion.div>
+  );
+}

--- a/components/recommendations/RecommendationSection.tsx
+++ b/components/recommendations/RecommendationSection.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { ChevronRight, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuth } from '@/components/auth/AuthProvider';
+import RecommendationCard from '@/components/recommendations/RecommendationCard';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ExperienceLevel, RecommendationWithBook } from '@/types';
+
+interface RecommendationSectionProps {
+  maxItems?: number;
+}
+
+interface RecommendationResponse {
+  recommendations: RecommendationWithBook[];
+  userExperienceLevel: ExperienceLevel;
+  totalBooks: number;
+}
+
+export default function RecommendationSection({ maxItems = 6 }: RecommendationSectionProps) {
+  const { user } = useAuth();
+  const [recommendations, setRecommendations] = useState<RecommendationWithBook[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRecommendations = useCallback(async () => {
+    if (!user) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = `/api/recommendations?userId=${user.id}&limit=${maxItems}`;
+
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error('レコメンドの取得に失敗しました');
+      }
+
+      const data: RecommendationResponse = await response.json();
+
+      setRecommendations(data.recommendations);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'エラーが発生しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [user, maxItems]);
+
+  useEffect(() => {
+    if (user) {
+      fetchRecommendations();
+    }
+  }, [user, fetchRecommendations]);
+
+  // ログインしていない場合は表示しない
+  if (!user) {
+    return null;
+  }
+
+  // エラーの場合は表示しない
+  if (error) {
+    return null;
+  }
+
+  // ローディング中の表示
+  if (loading) {
+    return (
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-yellow-500" />
+            あなたにおすすめ
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex-shrink-0 w-80">
+                <Skeleton className="h-48 w-full rounded-lg" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // レコメンドがない場合は表示しない
+  if (recommendations.length === 0) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="mb-6"
+    >
+      <Card>
+        <CardHeader className="pb-4">
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-yellow-500" />
+              あなたにおすすめ
+            </CardTitle>
+            {recommendations.length >= maxItems && (
+              <Link href="/recommendations">
+                <Button variant="ghost" size="sm" className="text-sm">
+                  もっと見る
+                  <ChevronRight className="h-4 w-4 ml-1" />
+                </Button>
+              </Link>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
+            {recommendations.map((recommendation, index) => (
+              <RecommendationCard
+                key={recommendation.book.id}
+                recommendation={recommendation}
+                index={index}
+              />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,4 +1,5 @@
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { createClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 
 // サーバーコンポーネント用のSupabaseクライアント
@@ -40,4 +41,22 @@ export const getServerUser = async () => {
     console.error('Unexpected error getting user:', error);
     return { user: null, error };
   }
+};
+
+// サーバーサイド用のSupabaseクライアント
+export const getSupabaseServerClient = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  const supabaseServiceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    throw new Error('Supabase URL or Service Key is missing');
+  }
+
+  return createClient(supabaseUrl, supabaseServiceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
 };

--- a/lib/utils/recommendations.ts
+++ b/lib/utils/recommendations.ts
@@ -1,0 +1,248 @@
+import { ExperienceLevel, RecommendationScore, Review } from '@/types';
+
+/**
+ * 経験年数から経験レベルを取得
+ */
+export const getExperienceLevel = (experienceYears: number): ExperienceLevel => {
+  if (experienceYears <= 2) {
+    return ExperienceLevel.BEGINNER;
+  } else if (experienceYears <= 4) {
+    return ExperienceLevel.INTERMEDIATE;
+  } else {
+    return ExperienceLevel.EXPERT;
+  }
+};
+
+/**
+ * 経験レベルに適した難易度範囲を取得
+ * より柔軟な範囲設定で、経験者ほど幅広い難易度を許容
+ */
+export const getOptimalDifficultyRange = (level: ExperienceLevel): [number, number] => {
+  switch (level) {
+    case ExperienceLevel.BEGINNER:
+      // 初学者：簡単〜普通レベルを推奨
+      return [1, 2.5];
+    case ExperienceLevel.INTERMEDIATE:
+      // 中級者：普通〜やや難しいレベルを推奨
+      return [2, 4];
+    case ExperienceLevel.EXPERT:
+      // 上級者：やや難しい〜難しいレベルを推奨（ただし簡単な書籍も許容）
+      return [3, 5];
+    default:
+      return [1, 5];
+  }
+};
+
+/**
+ * レビューデータから書籍のレコメンドスコアを計算
+ */
+export const calculateRecommendationScore = (
+  bookId: string,
+  reviews: Review[],
+  userExperienceLevel: ExperienceLevel
+): RecommendationScore | null => {
+  if (reviews.length === 0) {
+    return null;
+  }
+
+  // 同じ経験レベルのレビューを抽出
+  const sameLevelReviews = reviews.filter(review => {
+    const reviewLevel = getExperienceLevel(review.experience_years);
+    return reviewLevel === userExperienceLevel;
+  });
+
+  // 隣接する経験レベルのレビューも含める（±1レベル）
+  const adjacentLevelReviews = reviews.filter(review => {
+    const reviewLevel = getExperienceLevel(review.experience_years);
+    const levels = [ExperienceLevel.BEGINNER, ExperienceLevel.INTERMEDIATE, ExperienceLevel.EXPERT];
+    const userLevelIndex = levels.indexOf(userExperienceLevel);
+    const reviewLevelIndex = levels.indexOf(reviewLevel);
+    return Math.abs(userLevelIndex - reviewLevelIndex) <= 1;
+  });
+
+  // 平均難易度を計算
+  const avgDifficulty =
+    reviews.reduce((sum, review) => sum + review.difficulty, 0) / reviews.length;
+
+  // 適切な難易度範囲を取得
+  const [minDifficulty, maxDifficulty] = getOptimalDifficultyRange(userExperienceLevel);
+
+  // スコア計算の各要素
+  const experienceMatchScore = calculateExperienceMatchScore(
+    sameLevelReviews.length,
+    reviews.length
+  );
+  const difficultyScore = calculateDifficultyScore(
+    avgDifficulty,
+    minDifficulty,
+    maxDifficulty,
+    userExperienceLevel
+  );
+  const positiveRateScore = calculatePositiveRateScore(adjacentLevelReviews);
+  const reviewCountScore = calculateReviewCountScore(reviews.length);
+
+  // 重み付きスコア計算
+  const totalScore =
+    experienceMatchScore * 0.4 +
+    difficultyScore * 0.3 +
+    positiveRateScore * 0.2 +
+    reviewCountScore * 0.1;
+
+  // レコメンド理由を生成
+  const reasons = generateRecommendationReasons(
+    sameLevelReviews.length,
+    avgDifficulty,
+    minDifficulty,
+    maxDifficulty,
+    adjacentLevelReviews,
+    reviews.length
+  );
+
+  return {
+    bookId,
+    score: Math.round(totalScore * 100) / 100, // 小数点2桁まで
+    reasons,
+    avgDifficulty: Math.round(avgDifficulty * 10) / 10, // 小数点1桁まで
+    reviewCount: reviews.length,
+    experienceLevelMatch: sameLevelReviews.length,
+  };
+};
+
+/**
+ * 経験年数マッチングスコアを計算 (0-100)
+ */
+const calculateExperienceMatchScore = (sameLevelCount: number, totalCount: number): number => {
+  if (totalCount === 0) return 0;
+  const ratio = sameLevelCount / totalCount;
+  return Math.min(ratio * 100, 100);
+};
+
+/**
+ * 難易度適合スコアを計算 (0-100)
+ * 経験年数に応じて難易度マッチングの偏りを調整
+ */
+const calculateDifficultyScore = (
+  avgDifficulty: number,
+  minDifficulty: number,
+  maxDifficulty: number,
+  userExperienceLevel: ExperienceLevel
+): number => {
+  if (avgDifficulty >= minDifficulty && avgDifficulty <= maxDifficulty) {
+    return 100;
+  } else if (avgDifficulty < minDifficulty) {
+    // 簡単すぎる場合の処理
+    const distance = minDifficulty - avgDifficulty;
+
+    // 経験年数に応じてペナルティを調整
+    let penalty: number;
+    switch (userExperienceLevel) {
+      case ExperienceLevel.BEGINNER:
+        // 初学者：簡単な書籍でも許容度高め
+        penalty = distance * 20;
+        break;
+      case ExperienceLevel.INTERMEDIATE:
+        // 中級者：バランス良く
+        penalty = distance * 25;
+        break;
+      case ExperienceLevel.EXPERT:
+        // 上級者：簡単すぎる書籍は退屈になりがち
+        penalty = distance * 35;
+        break;
+      default:
+        penalty = distance * 30;
+    }
+
+    return Math.max(100 - penalty, 10); // 最低10点は保証
+  } else {
+    // 難しすぎる場合の処理
+    const distance = avgDifficulty - maxDifficulty;
+
+    // 経験年数に応じてペナルティを調整
+    let penalty: number;
+    switch (userExperienceLevel) {
+      case ExperienceLevel.BEGINNER:
+        // 初学者：難しい書籍は大幅減点
+        penalty = distance * 60;
+        break;
+      case ExperienceLevel.INTERMEDIATE:
+        // 中級者：やや厳しめ
+        penalty = distance * 45;
+        break;
+      case ExperienceLevel.EXPERT:
+        // 上級者：難しい書籍も挑戦可能
+        penalty = distance * 30;
+        break;
+      default:
+        penalty = distance * 40;
+    }
+
+    return Math.max(100 - penalty, 5); // 最低5点は保証
+  }
+};
+
+/**
+ * 高評価率スコアを計算 (0-100)
+ */
+const calculatePositiveRateScore = (reviews: Review[]): number => {
+  if (reviews.length === 0) return 0;
+
+  // 難易度3以下を「高評価」とみなす
+  const positiveReviews = reviews.filter(review => review.difficulty <= 3);
+  const positiveRate = positiveReviews.length / reviews.length;
+
+  return positiveRate * 100;
+};
+
+/**
+ * レビュー数スコアを計算 (0-100)
+ */
+const calculateReviewCountScore = (reviewCount: number): number => {
+  // レビュー数が多いほど信頼性が高い
+  // 10件以上で満点、それ以下は線形に減少
+  return Math.min((reviewCount / 10) * 100, 100);
+};
+
+/**
+ * レコメンド理由を生成
+ */
+const generateRecommendationReasons = (
+  sameLevelCount: number,
+  avgDifficulty: number,
+  minDifficulty: number,
+  maxDifficulty: number,
+  adjacentLevelReviews: Review[],
+  totalReviewCount: number
+): string[] => {
+  const reasons: string[] = [];
+
+  // 同じ経験レベルのレビューが多い
+  if (sameLevelCount >= 3) {
+    reasons.push('🎯 あなたと同じ経験レベルの方に高評価');
+  }
+
+  // 適切な難易度
+  if (avgDifficulty >= minDifficulty && avgDifficulty <= maxDifficulty) {
+    reasons.push('📚 適切な難易度レベル');
+  }
+
+  // 高評価率が高い
+  if (adjacentLevelReviews.length > 0) {
+    const positiveRate =
+      adjacentLevelReviews.filter(r => r.difficulty <= 3).length / adjacentLevelReviews.length;
+    if (positiveRate >= 0.7) {
+      reasons.push('⭐ 多くの方から高評価');
+    }
+  }
+
+  // レビュー数が多い
+  if (totalReviewCount >= 5) {
+    reasons.push('📊 豊富なレビューデータ');
+  }
+
+  // 理由がない場合のデフォルト
+  if (reasons.length === 0) {
+    reasons.push('💡 おすすめの一冊');
+  }
+
+  return reasons;
+};

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>http://localhost:3000/sitemap.xml</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/robots.txt</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/profile</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/search</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>1</priority></url>
-<url><loc>http://localhost:3000/books</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.9</priority></url>
-<url><loc>http://localhost:3000/scan</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>http://localhost:3000/privacy-policy</loc><lastmod>2025-05-25T10:40:02.288Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/robots.txt</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/sitemap.xml</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/recommendations</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/privacy-policy</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/search</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/books</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.9</priority></url>
+<url><loc>http://localhost:3000</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>1</priority></url>
+<url><loc>http://localhost:3000/profile</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>http://localhost:3000/scan</loc><lastmod>2025-05-27T16:47:44.305Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,3 +42,38 @@ export type UserBook = {
   added_at: string | null;
   finished_at: string | null;
 };
+
+// レコメンド機能関連の型定義
+export enum ExperienceLevel {
+  BEGINNER = 'beginner', // 0-2年 (未経験、1年未満、1-3年)
+  INTERMEDIATE = 'intermediate', // 3-4年 (3-5年)
+  EXPERT = 'expert', // 5年以上
+}
+
+export type RecommendationScore = {
+  bookId: string;
+  score: number;
+  reasons: string[];
+  avgDifficulty: number;
+  reviewCount: number;
+  experienceLevelMatch: number; // 同じ経験レベルのレビュー数
+};
+
+export type RecommendationWithBook = {
+  book: Book;
+  score: number;
+  reasons: string[];
+  avgDifficulty: number;
+  reviewCount: number;
+  experienceLevelMatch: number;
+};
+
+export type RecommendationCache = {
+  experienceLevel: ExperienceLevel;
+  bookId: string;
+  avgDifficulty: number;
+  reviewCount: number;
+  sameLevelReviews: number;
+  positiveRate: number;
+  updatedAt: string;
+};


### PR DESCRIPTION
## 概要
ユーザーの経験年数に基づいて適切な技術書をレコメンドする機能を実装しました。

## 実装内容

### 📊 レコメンドアルゴリズム
- **経験年数マッチング (40%)**: ユーザーの経験レベルに適した書籍を優先
- **適切な難易度 (30%)**: レベル別の最適な難易度範囲を設定
- **高評価率 (20%)**: 高評価レビューが多い書籍を優先
- **レビュー数 (10%)**: 十分なレビューがある書籍を優先

### 🎯 経験レベル分類
- **BEGINNER (0-2年)**: 基礎的な書籍を推薦
- **INTERMEDIATE (3-4年)**: 実践的な書籍を推薦  
- **EXPERT (5年以上)**: 高度な書籍を推薦

### 🚀 新機能
- **メインページレコメンド**: `/books`ページに最大6冊表示
- **専用一覧ページ**: `/recommendations`でページネーション対応
- **検索時非表示**: 検索中はレコメンドセクションを非表示
- **レスポンシブ対応**: モバイル・デスクトップ両対応

### 🎨 UI/UX改善
- **星評価表示**: 5段階のおすすめ度を視覚的に表示
- **カード全体クリック**: カード全体から書籍詳細に遷移
- **難易度タグ統一**: 既存の書籍一覧と同じデザイン
- **アニメーション**: Framer Motionによる滑らかな表示

### 🔧 技術実装
- **APIエンドポイント**: `GET /api/recommendations`
- **型安全性**: TypeScriptによる厳密な型定義
- **サーバーサイド処理**: Supabaseサーバークライアント使用
- **パフォーマンス**: useCallbackによる最適化

## 関連Issue
Closes #96

## テスト
- ✅ 全テストケース通過
- ✅ Linter/Prettier通過
- ✅ ビルド成功確認

## スクリーンショット
レコメンド機能が正常に動作し、ユーザーの経験年数（4年・中級者）に基づいて適切な書籍が表示されることを確認済み。