### PR TITLE
【フロントエンド】輪読会ホーム画面 UI作成

### DIFF
--- a/components/reading-circles/ReadingCircleHome.tsx
+++ b/components/reading-circles/ReadingCircleHome.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+
+// 型定義（テストのダミーデータに合わせる）
+type Circle = {
+  id: string;
+  title: string;
+  members: number;
+  progress: number;
+  status: string;
+  nextEvent: string;
+};
+
+type Props = {
+  circles: Circle[];
+};
+
+const ReadingCircleHome: React.FC<Props> = ({ circles }) => {
+  // 次回開催予定（最も近い日付）
+  const nextCircle = [...circles].sort((a, b) => a.nextEvent.localeCompare(b.nextEvent))[0];
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-6">
+      {/* 次回開催予定カード */}
+      <Card>
+        <CardHeader>
+          <CardTitle>次回開催予定</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-2">
+            <div className="font-bold text-lg">{nextCircle.title}</div>
+            <div>開催日: {nextCircle.nextEvent}</div>
+            <div>参加メンバー: {nextCircle.members}人</div>
+            <Badge>{nextCircle.status}</Badge>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* マイ読書会カード一覧 */}
+      <div className="space-y-4">
+        {circles.map(circle => (
+          <Card key={circle.id}>
+            <CardHeader>
+              <CardTitle>{circle.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-4">
+                <div className="flex-1">
+                  <div>参加メンバー: {circle.members}人</div>
+                  <div className="flex items-center gap-2 mt-2">
+                    <Badge>{circle.status}</Badge>
+                    <div className="w-32">
+                      <Progress value={circle.progress} data-testid="circle-progress-bar" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 新規作成ボタン */}
+      <div className="flex justify-end">
+        <Button>新規作成</Button>
+      </div>
+    </div>
+  );
+};
+
+export default ReadingCircleHome;

--- a/tests/components/reading-circles/ReadingCircleHome.test.tsx
+++ b/tests/components/reading-circles/ReadingCircleHome.test.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+// 仮のコンポーネントパス（後で正しいパスに修正）
+import ReadingCircleHome from '@/components/reading-circles/ReadingCircleHome';
+
+// ダミーデータ
+const mockCircles = [
+  {
+    id: '1',
+    title: 'React入門読書会',
+    members: 5,
+    progress: 60,
+    status: '進行中',
+    nextEvent: '2024-07-01',
+  },
+  {
+    id: '2',
+    title: 'AI時代の読書術',
+    members: 8,
+    progress: 0,
+    status: '募集中',
+    nextEvent: '2024-07-10',
+  },
+  {
+    id: '3',
+    title: 'Web技術大全',
+    members: 10,
+    progress: 100,
+    status: '完了',
+    nextEvent: '2024-06-20',
+  },
+];
+
+describe('ReadingCircleHome', () => {
+  it('次回開催予定カードが表示される', () => {
+    render(<ReadingCircleHome circles={mockCircles} />);
+    expect(screen.getByText('次回開催予定')).toBeInTheDocument();
+  });
+
+  it('マイ読書会カードが全て表示される', () => {
+    render(<ReadingCircleHome circles={mockCircles} />);
+    expect(screen.getAllByText('React入門読書会').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('AI時代の読書術').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Web技術大全').length).toBeGreaterThan(0);
+  });
+
+  it('進捗バーが表示される', () => {
+    render(<ReadingCircleHome circles={mockCircles} />);
+    expect(screen.getAllByTestId('circle-progress-bar').length).toBeGreaterThan(0);
+  });
+
+  it('ステータスバッジが表示される', () => {
+    render(<ReadingCircleHome circles={mockCircles} />);
+    expect(screen.getAllByText('進行中').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('募集中').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('完了').length).toBeGreaterThan(0);
+  });
+
+  it('新規作成ボタンが表示される', () => {
+    render(<ReadingCircleHome circles={mockCircles} />);
+    expect(screen.getByRole('button', { name: /新規作成/ })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要\n- 輪読会ホーム画面のUIコンポーネントを新規実装（Issue #131）\n- 次回開催予定カード、マイ読書会カード、進捗バー、ステータスバッジ、新規作成ボタンを含む\n- UIのみ・ダミーデータで動作\n- Jest + React Testing Libraryでテスト済み（TDDサイクル遵守）\n\nご確認よろしくお願いします。